### PR TITLE
Zeek 3.x updates

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -1,0 +1,1 @@
+bro-pkg.meta


### PR DESCRIPTION
Addressing comment in scripts/bzar_smb2_detect.zeek about preferring the smb2_write_response event over smb2_write_request to detect file writes